### PR TITLE
Catch the case where a user has no uid

### DIFF
--- a/db_governor.spec
+++ b/db_governor.spec
@@ -1,5 +1,5 @@
 %define g_version   1.0
-%define g_release   65
+%define g_release   66
 %define g_key_library 1
 
 Name: governor-mysql
@@ -242,6 +242,9 @@ echo "Instruction: how to create whole database backup - http://docs.cloudlinux.
 /usr/share/lve/dbgovernor/cpanel/tmp
 
 %changelog
+* Fri Jul 04 2014 Alexey Berezhok <aberezhok@cloudlinux.com> 1.0-66
+- Catch the case where a user has no uid in DA dbuser-map
+
 * Thu Jul 03 2014 Alexey Berezhok <aberezhok@cloudlinux.com> 1.0-65
 - removed duplicate usernames from DA dbuser-map
 

--- a/install/da/dbgovernor_map.py
+++ b/install/da/dbgovernor_map.py
@@ -18,8 +18,11 @@ def get_dauser( path ):
                 f = open( fileDomains )
                 if len( f.readline() ) > 0:
                     userName = userDir[ 2: ]
-                    p = pwd.getpwnam( userName )
-                    users[userName] = p.pw_uid
+                    try:
+                        p = pwd.getpwnam( userName )
+                        users[userName] = p.pw_uid
+                    except KeyError:
+                        print "Warning: user '%s' has no uid!" % userName
                 f.close()
             except IOError:
                 print( "No file " + fileDomains )


### PR DESCRIPTION
On some production systems we seem to have directadmin users without
corresponding /etc/passwd entry. While this is an error, we make this script
more robust by catching this case.
